### PR TITLE
Script to generate the commit hook restriction

### DIFF
--- a/scripts/generate_commit_hook.sh
+++ b/scripts/generate_commit_hook.sh
@@ -12,18 +12,18 @@ cat > "$HOOK_FILE" << 'EOF'
 
 # Hook to enforce conventional commit messages
 # Format: type(scope): description
-# Types: feat, fix, docs, style, refactor, perf, test, chore
+# Types: feat, fix, rm, upt, docs, style, refactor, perf, test, chore
 
 COMMIT_MSG_FILE=$1
 COMMIT_MSG=$(cat $COMMIT_MSG_FILE)
 
 # Regex for conventional commit
-REGEX="^(feat|fix|docs|style|refactor|perf|test|chore)(\(.+\))?: .+"
+REGEX="^(feat|fix|rm|upt|docs|style|refactor|perf|test|chore)(\(.+\))?: .+"
 
 if ! [[ $COMMIT_MSG =~ $REGEX ]]; then
     echo -e "\033[0;31mERROR: Commit message does not follow conventional commit format.\033[0m"
     echo -e "\033[0;33mExpected format: type(scope): description\033[0m"
-    echo -e "\033[0;33mTypes: feat, fix, docs, style, refactor, perf, test, chore\033[0m"
+    echo -e "\033[0;33mTypes: feat, fix, rm, upt, docs, style, refactor, perf, test, chore\033[0m"
     echo -e "\033[0;33mExample: feat: add new feature\033[0m"
     echo -e "\033[0;33mYour message: $COMMIT_MSG\033[0m"
     exit 1


### PR DESCRIPTION
This pull request adds a new script to help enforce conventional commit message standards by generating a Git commit hook. The script creates a `commit-msg` hook that checks commit messages for the correct format and warns users if they're committing directly to the `main` branch.

Commit message enforcement:

* Adds `scripts/generate_commit_hook.sh`, a script that sets up a `commit-msg` Git hook to enforce the conventional commit format (`type(scope): description`) and provides user feedback on errors.

Branch safety warning:

* The generated hook also issues a warning if a commit is made directly to the `main` branch.