### PR TITLE
CI release pipeline

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -181,3 +181,42 @@ jobs:
           prerelease: false
           artifacts: "rtype-unix-source-${{ github.run_number }}.zip"
           artifactContentType: application/zip
+
+  create_windows_release:
+    name: create windows release
+    needs: [run_all_tests]
+    if: ${{ github.event_name == 'push' }}
+    environment: RTYPE
+    runs-on: windows-latest
+    steps:
+      - name: CHECKOUT
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: INSTALL DEPENDENCIES
+        run: |
+          git clone https://github.com/Microsoft/vcpkg.git
+          cd vcpkg
+          .\bootstrap-vcpkg.bat
+          echo "VCPKG_ROOT=$PWD" >> $env:GITHUB_ENV
+
+      - name: BUILD PROJECT
+        run: |
+          .\scripts\compile_project.bat
+
+      - name: CREATE WINDOWS RELEASE
+        uses: ncipollo/release-action@v1
+        with:
+          tag: windows-latest-${{ github.run_number }}
+          name: Windows Release ${{ github.run_number }}
+          body: |
+            Automated Windows release for run number ${{ github.run_number }}.
+
+            ## Installation
+            1. Download the executable files
+            2. Run the client or server executable directly
+          draft: false
+          prerelease: false
+          artifacts: "*.exe"
+          artifactContentType: application/vnd.microsoft.portable-executable


### PR DESCRIPTION
This pull request adds automated workflows to build and release both Unix and Windows versions of the project whenever code is pushed. These workflows handle packaging source files and executables, and publish releases with installation instructions for each platform.

### Release automation

* Added a `create_unix_release` workflow that packages the source files into a zip archive and publishes a release with installation steps for Unix systems.
* Added a `create_windows_release` workflow that installs dependencies, builds the project, and publishes a release containing the Windows executables and instructions.