### PR TITLE
fix(build): update paths for Windows binaries in actions.yml

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -369,12 +369,13 @@ jobs:
       - name: CREATE WINDOWS BINARIES ARCHIVE
         run: |
           New-Item -ItemType Directory -Force -Path "r-type-client-windows"
-          Copy-Item -Path "build\windows\bin\client\*.exe" -Destination "r-type-client-windows\" -ErrorAction SilentlyContinue
-          Copy-Item -Path "build\windows\bin\client\*.dll" -Destination "r-type-client-windows\" -ErrorAction SilentlyContinue
+          Copy-Item -Path "r-type_client.exe" -Destination "r-type-client-windows\" -ErrorAction SilentlyContinue
+          Copy-Item -Path "build\windows\bin\client\Release\*.dll" -Destination "r-type-client-windows\" -ErrorAction SilentlyContinue
           Compress-Archive -Path "r-type-client-windows" -DestinationPath "r-type-client-windows-${{ needs.calculate_version.outputs.version }}.zip"
+
           New-Item -ItemType Directory -Force -Path "r-type-server-windows"
-          Copy-Item -Path "build\windows\bin\server\*.exe" -Destination "r-type-server-windows\" -ErrorAction SilentlyContinue
-          Copy-Item -Path "build\windows\bin\server\*.dll" -Destination "r-type-server-windows\" -ErrorAction SilentlyContinue
+          Copy-Item -Path "r-type_server.exe" -Destination "r-type-server-windows\" -ErrorAction SilentlyContinue
+          Copy-Item -Path "build\windows\bin\server\Release\*.dll" -Destination "r-type-server-windows\" -ErrorAction SilentlyContinue
           Compress-Archive -Path "r-type-server-windows" -DestinationPath "r-type-server-windows-${{ needs.calculate_version.outputs.version }}.zip"
 
       - name: UPLOAD WINDOWS CLIENT ARTIFACT


### PR DESCRIPTION
This pull request updates the build and packaging steps for Windows binaries in the GitHub Actions workflow to ensure the correct files are included in the release archives. The changes improve the reliability of the release process by specifying the exact executable and DLL locations for both client and server builds.

**Windows packaging improvements:**

* The client executable is now copied directly from `r-type_client.exe` instead of using a wildcard pattern in the build directory.
* The client DLLs are now copied from the `build\windows\bin\client\ReleaseThis pull request updates the build and packaging steps for Windows binaries in the GitHub Actions workflow to ensure the correct files are included in the release archives. The changes improve the reliability of the release process by specifying the exact executable and DLL locations for both client and server builds.

**Windows packaging improvements:**

* The client executable is now copied directly from `r-type_client.exe` instead of using a wildcard pattern in the build directory.
 directory, ensuring only release DLLs are included.
* The server executable is now copied directly from `r-type_server.exe` instead of using a wildcard pattern in the build directory.
* The server DLLs are now copied from the `build\windows\bin\server\ReleaseThis pull request updates the build and packaging steps for Windows binaries in the GitHub Actions workflow to ensure the correct files are included in the release archives. The changes improve the reliability of the release process by specifying the exact executable and DLL locations for both client and server builds.

**Windows packaging improvements:**

* The client executable is now copied directly from `r-type_client.exe` instead of using a wildcard pattern in the build directory.
* The client DLLs are now copied from the `build\windows\bin\client\ReleaseThis pull request updates the build and packaging steps for Windows binaries in the GitHub Actions workflow to ensure the correct files are included in the release archives. The changes improve the reliability of the release process by specifying the exact executable and DLL locations for both client and server builds.

**Windows packaging improvements:**

* The client executable is now copied directly from `r-type_client.exe` instead of using a wildcard pattern in the build directory.
 directory, ensuring only release DLLs are included.
* The server executable is now copied directly from `r-type_server.exe` instead of using a wildcard pattern in the build directory.
 directory, ensuring only release DLLs are included.