### PR TITLE
Update semantic version tag retrieval

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -263,11 +263,15 @@ jobs:
       - name: CALCULATE SEMANTIC VERSION
         id: semver
         run: |
-          # Get the latest tag
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # Get the latest semantic version tag (v*.*.*)
+          LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
+          echo "Latest semantic version tag: $LATEST_TAG"
           VERSION=${LATEST_TAG#v}
           
-          # SSeparate major.minor.patch
+          # Separate major.minor.patch
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
           # Increment according to the type


### PR DESCRIPTION
This pull request updates the semantic version calculation logic in the GitHub Actions workflow to more reliably identify and handle semantic version tags. The main change ensures that only tags matching the semantic version pattern (`v*.*.*`) are considered, and provides a fallback if no such tag exists.

Improvements to version handling:

* Updated the logic in `.github/workflows/actions.yml` to fetch the latest semantic version tag using `git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1`, ensuring only valid semantic version tags are used. Added a fallback to `v0.0.0` if no tag is found.