### PR TITLE
Fix context creation of certain entities

### DIFF
--- a/common/systems/shooting/ShootingSystem.cpp
+++ b/common/systems/shooting/ShootingSystem.cpp
@@ -22,6 +22,7 @@
 #include "../../constants.hpp"
 #include "../../../client/components/rendering/RectangleRenderComponent.hpp"
 #include "../../Prefab/entityPrefabManager/EntityPrefabManager.hpp"
+#include "../../ECS/entity/EntityCreationContext.hpp"
 namespace ecs {
 
 ShootingSystem::ShootingSystem() {
@@ -72,7 +73,7 @@ void ShootingSystem::update(
         }
 
         if (pattern.shotCount == 1) {
-            spawnProjectile(registry, prefab, spawnPos, baseAngle);
+            spawnProjectile(registry, resourceManager, prefabName, spawnPos, baseAngle);
         } else {
             float totalSpread = pattern.angleSpread * static_cast<float>(
                 pattern.shotCount - 1
@@ -91,7 +92,7 @@ void ShootingSystem::update(
                     );
                 }
 
-                spawnProjectile(registry, prefab, offsetPosition, angle);
+                spawnProjectile(registry, resourceManager, prefabName, offsetPosition, angle);
             }
         }
 
@@ -107,14 +108,15 @@ void ShootingSystem::update(
 
 void ShootingSystem::spawnProjectile(
     std::shared_ptr<Registry> registry,
-    std::shared_ptr<IPrefab> prefab,
+    std::shared_ptr<ResourceManager> resourceManager,
+    const std::string& prefabName,
     const math::Vector2f &position,
     float angle
 ) {
-    if (!prefab)
-        return;
-
-    Entity projectileEntity = prefab->instantiate(registry);
+    auto prefabManager = resourceManager->get<EntityPrefabManager>();
+    Entity projectileEntity = prefabManager->createEntityFromPrefab(
+        prefabName, registry, ecs::EntityCreationContext::forServer()
+    );
 
     auto transform = registry->getComponent<TransformComponent>(projectileEntity);
     if (transform) {

--- a/common/systems/shooting/ShootingSystem.hpp
+++ b/common/systems/shooting/ShootingSystem.hpp
@@ -15,7 +15,6 @@
 #include "../../components/permanent/TransformComponent.hpp"
 #include "../../components/permanent/VelocityComponent.hpp"
 #include "../../types/Vector2f.hpp"
-#include "../../Prefab/IPrefab.hpp"
 #include <cmath>
 #include <string>
 
@@ -35,7 +34,8 @@ class ShootingSystem : public ASystem {
     private:
         void spawnProjectile(
             std::shared_ptr<Registry> registry,
-            std::shared_ptr<IPrefab> prefab,
+            std::shared_ptr<ResourceManager> resourceManager,
+            const std::string& prefabName,
             const math::Vector2f &position,
             float angle
         );

--- a/server/gsm/states/scenes/InGame/InGameState.cpp
+++ b/server/gsm/states/scenes/InGame/InGameState.cpp
@@ -61,7 +61,7 @@ void InGameState::enter() {
     if (_resourceManager->has<EntityPrefabManager>()) {
         auto prefabManager = _resourceManager->get<EntityPrefabManager>();
         prefabManager->createEntityFromPrefab("player",
-            _resourceManager->get<ecs::Registry>());
+            _resourceManager->get<ecs::Registry>(), ecs::EntityCreationContext::forServer());
     } else {
         throw std::runtime_error("EntityPrefabManager not found in ResourceManager");
     }


### PR DESCRIPTION
This pull request refactors how projectiles are spawned in the `ShootingSystem`, shifting from using direct prefab instances to using the `EntityPrefabManager` and `ResourceManager`. This change standardizes entity creation and aligns projectile instantiation with the approach used elsewhere in the codebase. Additionally, the `spawnProjectile` method signature and its usage are updated to support this new approach.

**Refactoring projectile spawning to use `EntityPrefabManager` and `ResourceManager`:**

* Updated `spawnProjectile` to accept a `ResourceManager` and prefab name instead of a direct `IPrefab` instance, and now uses `EntityPrefabManager::createEntityFromPrefab` for projectile creation (`ShootingSystem.cpp`, `ShootingSystem.hpp`). [[1]](diffhunk://#diff-6f694ee519890bb48b9e72f3b812e4032ac76ebb4bdcc547383bca297b293301L75-R76) [[2]](diffhunk://#diff-6f694ee519890bb48b9e72f3b812e4032ac76ebb4bdcc547383bca297b293301L94-R95) [[3]](diffhunk://#diff-6f694ee519890bb48b9e72f3b812e4032ac76ebb4bdcc547383bca297b293301L110-R119) [[4]](diffhunk://#diff-fe724fa0fa2e9786dda099d9af2ea3220a93ec3f3d5c93e8d2911b7a1aff4624L38-R38)
* Removed the direct include and usage of `IPrefab` in favor of the new entity creation flow (`ShootingSystem.hpp`).

**Consistency in entity creation context:**

* Updated the call to `createEntityFromPrefab` for the player entity in `InGameState` to also use `EntityCreationContext::forServer()`, ensuring consistent context usage for server-side entity creation (`InGameState.cpp`).

**Dependency adjustments:**

* Added the include for `EntityCreationContext` to support the new entity creation method (`ShootingSystem.cpp`).