### PR TITLE
Include configs and assets in release packages for Unix and Windows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -156,6 +156,15 @@ jobs:
       - name: SETUP VCPKG
         uses: ./.github/actions/setup-vcpkg
 
+      - name: CACHE CMAKE BUILD
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/unix/bin
+          key: ${{ runner.os }}-cmake-build-${{ hashFiles('**/CMakeLists.txt', '**/vcpkg.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-build-${{ hashFiles('**/CMakeLists.txt', '**/vcpkg.json') }}-
+
       - name: RUN COMPILATION
         run: |
           chmod +x ./scripts/compile_project.sh


### PR DESCRIPTION
This pull request updates the packaging process in `.github/workflows/actions.yml` to ensure that configuration files are included in both the Unix source archive and Windows build artifacts. The changes improve deployment completeness by packaging necessary `configs` directories for both server and client builds.

Packaging improvements:

* The `configs` and `assets` directories are now included when creating the Unix source archive, ensuring all required files are present for builds on Unix systems.
* For Windows server builds, a `configs` directory is created and populated with configuration files, which are then included in the server zip artifact.
* For Windows client builds, a `configs` directory is similarly created and populated, ensuring client artifacts also contain necessary configuration files.