### PR TITLE
Fix the release one more time

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -287,7 +287,7 @@ jobs:
       - name: CREATE UNIX SOURCE ARCHIVE
         run: |
           mkdir -p release-package
-          cp -r client server common configs assets libs scripts tests CMakeLists.txt CMakePresets.json vcpkg.json libraries/ release-package/
+          cp -r client server common configs assets libs scripts tests CMakeLists.txt CMakePresets.json vcpkg.json libraries release-package/
           cd release-package
           tar -czf ../r-type-unix-${{ needs.calculate_version.outputs.version }}.tar.gz .
           cd ..


### PR DESCRIPTION
This pull request makes a minor change to the release packaging process in the GitHub Actions workflow. The `libraries` directory is now included in the UNIX source archive, ensuring that all necessary files are packaged for release.