### PR TITLE
One more time

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -205,7 +205,7 @@ jobs:
         id: get_version_type
         run: |
           # Get labels from the latest merged PR
-          PR_NUMBER=$(gh pr list --state merged --limit 1 --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --state merged --limit 10 --json mergedAt,number --jq 'sort_by(.mergedAt) | reverse | .[0].number')
           if [ -n "$PR_NUMBER" ]; then
             LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name')
             echo "Labels found: $LABELS"


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow. The change improves how the latest merged pull request is determined by sorting the last 10 merged PRs by their merge time, ensuring the most recent one is always selected.

- Workflow improvement:
  * [`.github/workflows/actions.yml`](diffhunk://#diff-2702f6f7d10a1bffbc8596d1a9925b1234bc4c7a6ff4c21ca6b34c13aa75780eL208-R208): Modified the script that fetches the latest merged PR number to sort the last 10 merged PRs by `mergedAt` and select the most recent, making the workflow more robust.