### PR TITLE
feat(Animation): add state retrieval method and adjust animation star…

### DIFF
--- a/client/ClientReceivedPacket.cpp
+++ b/client/ClientReceivedPacket.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 #include <string>
 #include <memory>
-
+#include <unordered_map>
 #include "ClientNetwork.hpp"
 #include "../common/debug.hpp"
 #include "../common/Parser/Parser.hpp"
@@ -17,6 +17,7 @@
 #include "../common/components/tags/LocalPlayerTag.hpp"
 #include "gsm/states/scenes/InGame/InGameState.hpp"
 #include "gsm/states/scenes/Results/ResultsState.hpp"
+#include "./components/rendering/AnimationComponent.hpp"
 
 /* Packet Handlers */
 void ClientNetwork::handleNoOp() {
@@ -252,5 +253,22 @@ void ClientNetwork::handleWhoAmI() {
     if (!registry->hasComponent<ecs::LocalPlayerTag>(entityId)) {
         registry->addComponent<ecs::LocalPlayerTag>
             (entityId, std::make_shared<ecs::LocalPlayerTag>());
+    }
+    if (registry->hasComponent<ecs::LocalPlayerTag>(entityId) &&
+        registry->hasComponent<ecs::AnimationComponent>(entityId)) {
+        auto animComp = registry->getComponent<ecs::AnimationComponent>(entityId);
+        std::unordered_map<std::string, std::shared_ptr<ecs::AnimationClip>>
+            states = animComp->getStates();
+        for (auto& kv : states) {
+            const std::shared_ptr<ecs::AnimationClip>& originalClip = kv.second;
+            if (!originalClip)
+                continue;
+            auto newClip = std::make_shared<ecs::AnimationClip>(*originalClip);
+            newClip->startHeight = 0.0f;
+            kv.second = newClip;
+        }
+        for (const auto& kv : states) {
+            animComp->addState(kv.first, kv.second);
+        }
     }
 }

--- a/client/components/rendering/AnimationComponent.hpp
+++ b/client/components/rendering/AnimationComponent.hpp
@@ -122,6 +122,9 @@ class AnimationComponent : public AComponent {
         void setMinAnimationTime(float time) { _minAnimationTime = time; }
         float getMinAnimationTime() const { return _minAnimationTime; }
 
+        std::unordered_map<std::string, std::shared_ptr<AnimationClip>> getStates() const {
+            return _states;
+        }
     private:
         std::unordered_map<std::string, std::shared_ptr<AnimationClip>> _states;
         std::vector<Transition> _transitions;

--- a/client/gsm/states/scenes/Results/ResultsState.cpp
+++ b/client/gsm/states/scenes/Results/ResultsState.cpp
@@ -34,7 +34,7 @@ void ResultsState::enter() {
     ecs::Entity textEntity = _registry->createEntity();
     std::string text = _isWin ? constants::WIN_TEXT : constants::LOSE_TEXT;
     _registry->addComponent(textEntity, std::make_shared<ecs::TextComponent>(
-        text, "assets/fonts/arial.ttf", gfx::color_t{255, 255, 255}));
+        text, "assets/fonts/abduction2002.ttf", gfx::color_t{255, 255, 255}));
     _registry->addComponent(textEntity,
         std::make_shared<ecs::TransformComponent>(
         math::Vector2f(constants::MAX_WIDTH / 2.0f - 50.0f,

--- a/configs/entities/players/player.json
+++ b/configs/entities/players/player.json
@@ -19,7 +19,7 @@
                     "frameHeight": 17.0,
                     "frameCount": 1,
                     "startWidth": 0.0,
-                    "startHeight": 0.0,
+                    "startHeight": 17.0,
                     "speed": 0.2,
                     "loop": true
                 },
@@ -29,7 +29,7 @@
                     "frameHeight": 17.0,
                     "frameCount": 2,
                     "startWidth": 0.0,
-                    "startHeight": 0.0,
+                    "startHeight": 17.0,
                     "speed": 0.2,
                     "loop": false
                 },
@@ -39,7 +39,7 @@
                     "frameHeight": 17.0,
                     "frameCount": 2,
                     "startWidth": 0.0,
-                    "startHeight": 0.0,
+                    "startHeight": 17.0,
                     "speed": 0.2,
                     "loop": false
                 }


### PR DESCRIPTION
This pull request introduces improvements to the animation system for player entities and updates the results screen font. The main focus is on resetting animation start heights for the local player and providing a method to access animation states, along with a visual update to the results text and configuration changes to player animations.

**Animation system improvements:**

* Added a `getStates()` method to the `AnimationComponent` class to allow retrieval of all animation states.
* In `ClientNetwork::handleWhoAmI`, added logic to reset the `startHeight` of all animation states to `0.0f` for the local player, ensuring consistent animation starting positions.
* Included the `AnimationComponent` header in `ClientReceivedPacket.cpp` to support the new animation logic.
* Added `#include <unordered_map>` to `ClientReceivedPacket.cpp` to support usage of unordered maps for animation states.

**Player animation configuration changes:**

* Updated `startHeight` from `0.0` to `17.0` for all player animation clips in `player.json`, likely to align with new animation frame layouts or requirements. [[1]](diffhunk://#diff-ca5724a347ce09b4cfff21b09d06548501b98a3beeb8ff67f2041ffaa7a7f6c7L22-R22) [[2]](diffhunk://#diff-ca5724a347ce09b4cfff21b09d06548501b98a3beeb8ff67f2041ffaa7a7f6c7L32-R32) [[3]](diffhunk://#diff-ca5724a347ce09b4cfff21b09d06548501b98a3beeb8ff67f2041ffaa7a7f6c7L42-R42)

**Visual/UI update:**

* Changed the results screen font from Arial to Abduction2002 for improved visual style in `ResultsState.cpp`.