### PR TITLE
update cache keys for vcpkg to include versioning

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -12,9 +12,9 @@ runs:
           vcpkg
           build/unix/bin/vcpkg_installed
           ~/.cache/vcpkg/archives
-        key: ${{ runner.os }}-vcpkg-${{ hashFiles('**/vcpkg.json', '**/CMakeLists.txt') }}
+        key: ${{ runner.os }}-vcpkg-v2-${{ hashFiles('**/vcpkg.json', '**/CMakeLists.txt') }}
         restore-keys: |
-          ${{ runner.os }}-vcpkg-
+          ${{ runner.os }}-vcpkg-v2-
 
     - name: CACHE VCPKG (Windows)
       if: runner.os == 'Windows'
@@ -24,9 +24,9 @@ runs:
           vcpkg
           build/windows/bin/vcpkg_installed
           C:\Users\runneradmin\AppData\Local\vcpkg\archives
-        key: ${{ runner.os }}-vcpkg-${{ hashFiles('**/vcpkg.json', '**/CMakeLists.txt') }}
+        key: ${{ runner.os }}-vcpkg-v2-${{ hashFiles('**/vcpkg.json', '**/CMakeLists.txt') }}
         restore-keys: |
-          ${{ runner.os }}-vcpkg-
+          ${{ runner.os }}-vcpkg-v2-
 
     - name: INSTALL VCPKG (Unix)
       if: runner.os != 'Windows'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -125,10 +125,10 @@ jobs:
             build/unix/bin
             vcpkg
             vcpkg_installed
-          key: ${{ runner.os }}-cmake-build-${{ hashFiles('**/CMakeLists.txt', '**/vcpkg.json', '**/*.cpp', '**/*.hpp') }}-${{ github.sha }}
+          key: ${{ runner.os }}-cmake-build-v2-${{ hashFiles('**/CMakeLists.txt', '**/vcpkg.json', '**/*.cpp', '**/*.hpp') }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-cmake-build-${{ hashFiles('**/CMakeLists.txt', '**/vcpkg.json') }}-
-            ${{ runner.os }}-cmake-build-
+            ${{ runner.os }}-cmake-build-v2-${{ hashFiles('**/CMakeLists.txt', '**/vcpkg.json') }}-
+            ${{ runner.os }}-cmake-build-v2-
 
       - name: RUN COMPILATION
         run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,12 +1,22 @@
 {
   "name": "r-type",
   "version": "1.0.0",
+  "builtin-baseline": "3bbc2809d3625cb83a0d7cbd413bd6ad769d46d4",
   "dependencies": [
     "sfml",
     "asio",
     "gtest",
     "nlohmann-json",
-    "lua",
+    {
+      "name": "lua",
+      "version>=": "5.4.6"
+    },
     "sol2"
+  ],
+  "overrides": [
+    {
+      "name": "lua",
+      "version": "5.4.6"
+    }
   ]
 }


### PR DESCRIPTION
This pull request updates the caching keys and configuration for vcpkg and CMake builds, and refines the dependency management for `lua` in the project. The main goals are to improve cache isolation, ensure reproducible builds, and explicitly specify the required version of `lua` for consistency across environments.

**Build and cache configuration updates:**

* Updated cache keys in `.github/actions/setup-vcpkg/action.yml` and `.github/workflows/actions.yml` to use a `-v2-` suffix, improving cache isolation and preventing conflicts with previous cache versions. [[1]](diffhunk://#diff-0ff0fd8418770c303ddd618608ce8f76494077d81dff3aa3af2082025b71df73L15-R17) [[2]](diffhunk://#diff-0ff0fd8418770c303ddd618608ce8f76494077d81dff3aa3af2082025b71df73L27-R29) [[3]](diffhunk://#diff-2702f6f7d10a1bffbc8596d1a9925b1234bc4c7a6ff4c21ca6b34c13aa75780eL128-R131)

**Dependency management improvements:**

* Added a `builtin-baseline` to `vcpkg.json` to ensure reproducible builds by pinning the vcpkg registry to a specific commit.
* Updated the `lua` dependency in `vcpkg.json` to explicitly require version 5.4.6 or newer, and added an override to force the use of version 5.4.6, ensuring consistency across all environments.