### PR TITLE
Initialize uninitialized value

### DIFF
--- a/common/FloatQuantization.hpp
+++ b/common/FloatQuantization.hpp
@@ -34,7 +34,7 @@ inline float dequantizeFloat(int32_t quantized, float precision) {
 
 inline uint64_t packQuantizedFloat(float value, float precision) {
     int32_t quantized = quantizeFloat(value, precision);
-    uint64_t result;
+    uint64_t result = 0;
     std::memcpy(&result, &quantized, sizeof(int32_t));
     return result;
 }


### PR DESCRIPTION
This pull request makes a minor improvement to the `packQuantizedFloat` function in `common/FloatQuantization.hpp`, ensuring that the `result` variable is always initialized before use. This change helps prevent potential issues with uninitialized variables.