### PR TITLE
fix(links): links now link to the good pages

### DIFF
--- a/documentation/docusaurus/docs/INTRO/project_overview.md
+++ b/documentation/docusaurus/docs/INTRO/project_overview.md
@@ -141,11 +141,11 @@ Please see our [Contributing Guide](../HOW-TO-CONTRIBUTE/htc-intro.md) for detai
 
 ## 📄 Additional Resources
 
-- **[Client Documentation](../CLIENT/client-intro.md)**: Client implementation details
-- **[Server Documentation](../SERVER/server-intro.md)**: Server architecture and protocols
-- **[ECS Documentation](../ECS/)**: Entity-Component-System framework
-- **[Network Protocol](../NETWORK/)**: PSJM protocol specification
-- **[Security](../SECURITY/)**: Security considerations
+- **[Client Documentation](../category/client-documentation/)**: Client implementation details
+- **[Server Documentation](../category/server-documentation/)**: Server architecture and protocols
+- **[ECS Documentation](../category/ecs-documentation/)**: Entity-Component-System framework
+- **[Network Protocol](../category/network-documentation/)**: PSJM protocol specification
+- **[Security](../category/security/)**: Security considerations
 
 ---
 


### PR DESCRIPTION
This pull request updates the links in the "Additional Resources" section of the project overview documentation to point to the new documentation category structure. This change ensures that users are directed to the correct, reorganized documentation pages.

- Documentation structure update:
  * Updated resource links in `project_overview.md` to reference the new category-based documentation paths for client, server, ECS, network protocol, and security documentation.